### PR TITLE
Ignore prefix when PRESIGN_URL is set to true

### DIFF
--- a/main.js
+++ b/main.js
@@ -270,17 +270,17 @@ ipcMain.on('save-recording', async (event, buffer) => {
 
     const result = await s3.upload(params).promise();
     let url;
-    if (process.env.URL_PREFIX) {
-      const prefix = process.env.URL_PREFIX.endsWith('/')
-        ? process.env.URL_PREFIX
-        : `${process.env.URL_PREFIX}/`;
-      url = `${prefix}${fileName}`;
-    } else if (PRESIGN_URL) {
+    if (PRESIGN_URL) {
       url = s3.getSignedUrl('getObject', {
         Bucket: BUCKET_NAME,
         Key: fileName,
         Expires: PRESIGN_URL_EXPIRY,
       });
+    } else if (process.env.URL_PREFIX) {
+      const prefix = process.env.URL_PREFIX.endsWith('/')
+        ? process.env.URL_PREFIX
+        : `${process.env.URL_PREFIX}/`;
+      url = `${prefix}${fileName}`;
     } else {
       url = result.Location;
     }


### PR DESCRIPTION
the expectation of copying the env vars from the README and changing: `PRESIGN_URL` to `true` and `ACL` to `private` is to finish a recording with the browser on the presigned url. But if the other env var from the readme `PREFIX_URL` is set, it would take the precedence before this patch.